### PR TITLE
Optimize get_blocker_deltas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "cetkaik_core"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +23,7 @@ name = "cetkaik_yhuap_move_candidates"
 version = "0.2.8"
 dependencies = [
  "cetkaik_core",
+ "num",
 ]
 
 [[package]]
@@ -24,6 +31,82 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ exclude = [ "renovate.json" ]
 
 [dependencies]
 cetkaik_core = "0.3.8"
+num = { version = "0.4.0", feature = ["alloc"] }

--- a/src/calculate_movable.rs
+++ b/src/calculate_movable.rs
@@ -68,30 +68,28 @@ fn apply_deltas(coord: Coord, deltas: &[[i32; 2]]) -> Vec<Coord> {
 
 fn get_blocker_deltas(delta: [i32; 2]) -> Vec<[i32; 2]> {
     /* blocking occurs only when there exists [dx_block, dy_block] such that
-    - the dot product with [dx, dy] is positive
-    - the cross product with [dx, dy] is zero
+    - dx is a positive multiple of dx_block
+    - dy is a positive multiple of dy_block
     - abs(dx_block, dy_block) < abs(dx, dy)
     */
     let [dx, dy] = delta;
+    let d_length = dx * dx + dy * dy;
+    let g = num::integer::gcd(dx, dy);
+    let qx = dx / g;
+    let qy = dy / g;
 
     let mut ans: Vec<[i32; 2]> = vec![];
 
-    for dx_block in -8..=8 {
-        for dy_block in -8..=8 {
-            if dx * dy_block - dy * dx_block != 0 {
-                continue;
-            } // cross product must be zero
-            if dx * dx_block + dy * dy_block <= 0 {
-                continue;
-            } // cross product must be positive
-            if dx_block * dx_block + dy_block * dy_block >= dx * dx + dy * dy {
-                continue;
-            }
-            // must be strictly small in absolute value
-
-            ans.push([dx_block, dy_block]);
+    for mult in 1.. {
+        let dx_block = mult * qx;
+        let dy_block = mult * qy;
+        let d_block_length = dx_block * dx_block + dy_block * dy_block;
+        if core::cmp::max(dx_block.abs(), dy_block.abs()) > 8 || d_block_length >= d_length {
+            break;
         }
+        ans.push([dx_block, dy_block]);
     }
+
     ans
 }
 


### PR DESCRIPTION
https://github.com/primenumber/cetkAIk で全体の実行時間のうち半分弱を占めていたので、速い実装に置き換えました
`delta` に縦・横・斜め45°しかないなら `signum(dx), signum(dy)` を使えそう？
本来であればVecでなくIteratorを返すのがよさそうだけど、現時点ではボトルネックの回避にはこれで十分でした